### PR TITLE
Fixing issue where index is undefined in count method of vbox

### DIFF
--- a/js/color-thief.js
+++ b/js/color-thief.js
@@ -274,7 +274,7 @@ var MMCQ = (function() {
                 for (i = vbox.r1; i <= vbox.r2; i++) {
                     for (j = vbox.g1; j <= vbox.g2; j++) {
                         for (k = vbox.b1; k <= vbox.b2; k++) {
-                             index = getColorIndex(i,j,k);
+                             var index = getColorIndex(i,j,k);
                              npix += (histo[index] || 0);
                         }
                     }


### PR DESCRIPTION
Had an issue where the index variable was throwing an undefined error a in Chrome.

This seems to have fixed the issue for me so please consider taking this pull request if it makes sense to you.
