### PR TITLE
make it work in node with requireJs

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -55,7 +55,7 @@ CanvasImage.prototype.removeCanvas = function () {
 };
 
 
-var ColorThief = function () {};
+this.ColorThief = function () {};
 
 /*
  * getColor(sourceImage[, quality])


### PR DESCRIPTION
with just a var, it is not possible to use this inside node and requireJs (it breaks shimming). By assigning ColorThief to the global namespace, we can set up a shim in requireJS config to make ColorThief available.

This does the exact same thing as the current version, in that ColorThief appears on the window in a browser. I would like to add proper AMD support quite soon.
