### PR TITLE
Update color-thief.js

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -127,11 +127,15 @@ ColorThief.prototype.getPalette = function(sourceImage, colorCount, quality) {
 
     // Send array to quantize function which clusters values
     // using median cut algorithm
-    var cmap    = MMCQ.quantize(pixelArray, colorCount);
-    var palette = cmap.palette();
-
-    // Clean up
-    image.removeCanvas();
+    try {
+        var cmap    = MMCQ.quantize(pixelArray, colorCount);
+        var palette = cmap.palette();
+    } catch(e) {
+        throw e;
+    } finally {
+        // Clean up
+        image.removeCanvas();
+    }
 
     return palette;
 };


### PR DESCRIPTION
images can make the MMCQ return errounous results, resulting in the following line to explode and no cleaning up the canvas afterwards.
probably one wants to look deeper into mmcq but this solves the issue for now in not leaving a canvas left in the dom
