### PR TITLE
Adding MIT license to source/metadata files

### DIFF
--- a/dist/color-thief.min.js
+++ b/dist/color-thief.min.js
@@ -4,8 +4,8 @@
  *
  * License
  * -------
- * Creative Commons Attribution 2.5 License:
- * http://creativecommons.org/licenses/by/2.5/
+ * MIT License:
+ * https://github.com/lokesh/color-thief/blob/master/LICENSE
  *
  * Thanks
  * ------

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   },
   "licenses": [
     {
-      "type": "Creative Commons Attribution 2.5 License",
-      "url": "http://creativecommons.org/licenses/by/2.5/"
+      "type": "MIT License",
+      "url": "https://github.com/lokesh/color-thief/blob/master/LICENSE"
     }
   ],
   "main": "dist/color-thief.min.js",

--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -4,8 +4,8 @@
  *
  * License
  * -------
- * Creative Commons Attribution 2.5 License:
- * http://creativecommons.org/licenses/by/2.5/
+ * MIT License:
+ * https://github.com/lokesh/color-thief/blob/master/LICENSE
  *
  * Thanks
  * ------


### PR DESCRIPTION
Per license update, changing source headers/metadata to identify licensing as MIT
