### PR TITLE
Fixed getColor description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ colorThief.getColor(sourceImage);
 
 ```js
 getColor(sourceImage[, quality])
-returns {r: num, g: num, b: num}
+returns [num, num, num]
 ```
 
 ###Build a color palette from an image


### PR DESCRIPTION
The README erroneously stated that getColor would return a js object with 'r', 'g' and 'b' members, instead it returns an array just like getPalette.
