### PR TITLE
Change how MMCQ.quantize counts colors in order to fix #19

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -548,10 +548,16 @@ var MMCQ = (function() {
 
         // inner function to do the iteration
         function iter(lh, target) {
-            var ncolors = 1,
+            var ncolors = lh.size(),
                 niters = 0,
                 vbox;
             while (niters < maxIterations) {
+                if (ncolors >= target) return;
+                if (niters++ > maxIterations) {
+//                    console.log("infinite loop; perhaps too few pixels!");
+                    return;
+                }
+
                 vbox = lh.pop();
                 if (!vbox.count())  { /* just put it back */
                     lh.push(vbox);
@@ -572,11 +578,6 @@ var MMCQ = (function() {
                     lh.push(vbox2);
                     ncolors++;
                 }
-                if (ncolors >= target) return;
-                if (niters++ > maxIterations) {
-//                    console.log("infinite loop; perhaps too few pixels!");
-                    return;
-                }
             }
         }
 
@@ -592,7 +593,7 @@ var MMCQ = (function() {
         }
 
         // next set - generate the median cuts using the (npix * vol) sorting.
-        iter(pq2, maxcolors - pq2.size());
+        iter(pq2, maxcolors);
 
         // calculate the actual colors
         var cmap = new CMap();


### PR DESCRIPTION
The inner function used by MMCQ.quantize was counting the number of colors
added to the palette, starting from 1. This only works when the PQueue passed
contains only 1 VBox; but the iter function is called twice, and the second
time, the VBox contains more than one color. This means that in some
circumstances it was counting the number of colors added incorrectly, and so
MMCQ.quantize (and ColorThief.getPalette) would sometimes return the wrong
number of colors, as reported in #19 . This commit changes iter to start counting at the actual
number of colors in the PQueue, so that it always returns the number of
colors requested.
