### PR TITLE
Fix the 'ReferenceError: index is not defined' for the index variable

### DIFF
--- a/src/color-thief.js
+++ b/src/color-thief.js
@@ -267,7 +267,7 @@ var MMCQ = (function() {
                 histo = vbox.histo;
             if (!vbox._count_set || force) {
                 var npix = 0,
-                    i, j, k;
+                    index, i, j, k;
                 for (i = vbox.r1; i <= vbox.r2; i++) {
                     for (j = vbox.g1; j <= vbox.g2; j++) {
                         for (k = vbox.b1; k <= vbox.b2; k++) {


### PR DESCRIPTION
Similar to other pull request: add index to the variable definition.

After joining and uglifyin the JS resources, color thief gives error with

'ReferenceError: index is not defined' 

when used with  "use strict".
