### PR TITLE
Pass mimetype when input is Buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "colorthief",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2174,6 +2174,11 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-type": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.3.0.tgz",
+      "integrity": "sha512-4E4Esq9KLwjYCY32E7qSmd0h7LefcniZHX+XcdJ4Wfx1uGJX7QCigiqw/U0yT7WOslm28yhxl87DJ0wHYv0RAA=="
     },
     "filename-regex": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "mustache": "^3.0.1"
     },
     "dependencies": {
+        "file-type": "12.3.0",
         "get-pixels": "^3.3.2",
         "quantize": "github:lokesh/quantize"
     }

--- a/src/color-thief-node.js
+++ b/src/color-thief-node.js
@@ -1,5 +1,6 @@
 const getPixels = require('get-pixels');
 const quantize = require('quantize');
+const fileType = require('file-type')
 
 function createPixelArray(imgData, pixelCount, quality) {
     const pixels = imgData;
@@ -47,8 +48,9 @@ function validateOptions(options) {
 }
 
 function loadImg(img) {
+    const type = Buffer.isBuffer(img) ? fileType(img).mime : null
     return new Promise((resolve, reject) => {
-        getPixels(img, function(err, data) {
+        getPixels(img, type, function(err, data) {
             if(err) {
                 reject(err)
             } else {

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -1,4 +1,5 @@
 const { resolve } = require('path');
+const { readFile } = require('fs');
 const ColorThief = require(resolve(process.cwd(), "dist/color-thief.js"));
 const img = resolve(process.cwd(), 'cypress/test-pages/img/rainbow-vertical.png');
 const chai = require("chai");
@@ -9,6 +10,13 @@ chai.use(require("chai-as-promised"));
 describe('getColor()', function() {
     it('returns valid color', function() {
         return expect(ColorThief.getColor(img)).to.eventually.have.lengthOf(3);
+    });
+
+    it('returns valid color when input is Buffer', function() {
+        readFile(img, function(err, data) {
+            const buffer = Buffer.from(data)
+            return expect(ColorThief.getColor(buffer)).to.eventually.have.lengthOf(3);
+        });
     });
 });
 


### PR DESCRIPTION
First, thanks for this great _Library_!

Working with this cool _Library_ (congrats and thanks!) in `node.js`, in particular making [responsimage](https://github.com/elrumordelaluz/responsimage/) I found that the `image` (input) value could be not only a path string to the image but also a `Buffer`, [since the `url` argument](https://github.com/scijs/get-pixels#install): 

> It can be a relative path, an http url, a data url, or an in-memory Buffer.

And this is cool, and sound coherent when working in `node`.
But in this scenario I found that the second argument `type` is needed:

> type is an optional mime type for the image (required when using a Buffer)

So made this PR to fix that part, adding the relative test. Keep in mind that I didn't include the `/dist` with bundled files.

Let me know in any case and thanks again for this great _Library_!