### PR TITLE
build: remove unused node-minify deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
         "cypress": "./node_modules/.bin/cypress open"
     },
     "devDependencies": {
-        "@node-minify/core": "^4.0.5",
-        "@node-minify/uglify-es": "^4.0.5",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "cypress": "^12.6.0",


### PR DESCRIPTION
These deps were used as part of the previous build process prior to the inclusion of `microbundle`.