### PR TITLE
Fix code with `image` in ES6 documentation

### DIFF
--- a/cypress/test-pages/es6-module.html
+++ b/cypress/test-pages/es6-module.html
@@ -18,18 +18,18 @@
         const colorThief = new ColorThief();
 
 
-        const img = document.querySelector('img');
+        const image = document.querySelector('img');
 
         function getColorFromImage(img) {
             const result = colorThief.getColor(img);
             document.querySelector('#result').innerText = result;
         }
 
-        if (img.complete) {
-            getColorFromImage(img);
+        if (image.complete) {
+            getColorFromImage(image);
         } else {
             image.addEventListener('load', function() {
-                getColorFromImage(img);
+                getColorFromImage(image);
             });
         }
     </script>


### PR DESCRIPTION
There was only `img` definition, but `image` usage.

I found a lot of `image` in source code (tests).

Also there is a possible conflict between root constant and function argument.