### PR TITLE
Add TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+declare module 'colorthief' {
+    /**
+     * Gets the dominant color from the image.
+     * @param img - The image source, either a Buffer or a path to a image.
+     * @param quality - An optional argument that determines how many pixels are skipped before the next one is sampled. Defaults to 10.
+     * @returns A promise that resolves to an array of three integers representing the RGB values of the dominant color.
+     */
+    export function getColor(img: Buffer | string, quality?: number): Promise<[number, number, number]>;
+    /**
+     * Gets a palette from the image by clustering similar colors.
+     * @param img - The image source, either a Buffer or a path to a image.
+     * @param colorCount - An optional argument that determines the number of colors in the palette. Defaults to 10.
+     * @param quality - An optional argument that determines how many pixels are skipped before the next one is sampled. Defaults to 10.
+     * @returns A promise that resolves to an array of arrays, each containing three integers representing the RGB values of a color in the palette.
+     */
+    export function getPalette(img: Buffer | string, colorCount?: number, quality?: number): Promise<[number, number, number][]>;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer';
 declare module 'colorthief' {
     /**
      * Gets the dominant color from the image.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "sharp": "^0.33.5"
             },
             "devDependencies": {
+                "@types/node": "^22.10.1",
                 "chai": "^4.2.0",
                 "chai-as-promised": "^7.1.1",
                 "cypress": "^13.15.0",
@@ -2437,11 +2438,14 @@
             "integrity": "sha512-oANmFZMnFQvb219SSBIhI1Ih/r4CvHDOzkWyJS/XRqkMrGH5/kaPSA1hQhdIBzouaE+5KpE/f5ylI9cujmckQg=="
         },
         "node_modules/@types/node": {
-            "version": "16.18.112",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.112.tgz",
-            "integrity": "sha512-EKrbKUGJROm17+dY/gMi31aJlGLJ75e1IkTojt9n6u+hnaTBDs+M1bIdOawpk2m6YUAXq/R2W0SxCng1tndHCg==",
+            "version": "22.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+            "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.20.0"
+            }
         },
         "node_modules/@types/parse-json": {
             "version": "4.0.2",
@@ -10229,7 +10233,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
             "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-            "devOptional": true,
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tunnel-agent": {
@@ -10394,6 +10398,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "cypress": "./node_modules/.bin/cypress open"
     },
     "devDependencies": {
+        "@types/node": "^22.10.1",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "cypress": "^13.15.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "types": ["node"],
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
### Description

This PR adds TypeScript declaration files for the `ColorThief` module. This will provide better type checking and IntelliSense support for developers using this module in TypeScript projects.

### Changes

- Added `index.d.ts` file with TypeScript declarations for the `ColorThief` module.
- Updated `tsconfig.json` to include the new declaration file.