### PR TITLE
feat: add CLI tool for extracting colors from images

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ swatches.Vibrant?.color.hex();
 - **Rich Color objects** — `.hex()`, `.rgb()`, `.hsl()`, `.oklch()`, `.css()`, contrast ratios, text color recommendations
 - **WCAG contrast** — `color.contrast.white`, `color.contrast.black`, `color.contrast.foreground`
 - **AbortSignal** — cancel in-flight extractions
+- **CLI** — `colorthief photo.jpg` with JSON, CSS, and ANSI output
 - **Zero runtime dependencies**
 
 ## API at a Glance
@@ -142,6 +143,53 @@ const palette = await getPalette(Buffer.from(data), { colorCount: 5 });
 ```
 
 Accepts file paths and Buffers. Uses [sharp](https://sharp.pixelplumbing.com/) for image decoding.
+
+## CLI
+
+```bash
+# Dominant color
+colorthief photo.jpg
+
+# Color palette
+colorthief palette photo.jpg
+
+# Semantic swatches
+colorthief swatches photo.jpg
+```
+
+### Output formats
+
+```bash
+# Default: ANSI color swatches
+colorthief photo.jpg
+# ▇▇ #e84393
+
+# JSON with full color data
+colorthief photo.jpg --json
+
+# CSS custom properties
+colorthief palette photo.jpg --css
+# :root {
+#     --color-1: #e84393;
+#     --color-2: #6c5ce7;
+# }
+```
+
+### Options
+
+```bash
+colorthief palette photo.jpg --count 5        # Number of colors (2-20)
+colorthief photo.jpg --quality 1              # Sampling quality (1=best)
+colorthief photo.jpg --color-space rgb        # Color space (rgb or oklch)
+```
+
+Stdin is supported — use `-` or pipe directly:
+
+```bash
+cat photo.jpg | colorthief -
+```
+
+Multiple files are supported. Output is prefixed with filenames, and `--json` wraps results in an object keyed by filename.
 
 ## Links
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
         "url": "https://github.com/lokesh/color-thief.git"
     },
     "license": "MIT",
+    "bin": {
+        "colorthief": "./dist/cli.js"
+    },
     "files": [
         "dist/",
         "src/"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,349 @@
+import { parseArgs } from 'node:util';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { getColor, getPalette, getSwatches } from './api.js';
+import type { Color, SwatchMap, SwatchRole } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Version
+// ---------------------------------------------------------------------------
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+const HELP = `
+Usage: colorthief [command] <file...> [options]
+
+Commands:
+  color      Extract dominant color (default)
+  palette    Extract color palette
+  swatches   Extract semantic swatches
+
+Arguments:
+  <file...>  Image file path(s). Use "-" for stdin.
+
+Options:
+  --json              Output as JSON
+  --css               Output as CSS custom properties
+  --count <n>         Number of palette colors (2-20, default 10)
+  --quality <n>       Sampling quality (1=best, default 10)
+  --color-space <s>   Color space: rgb or oklch (default oklch)
+  -h, --help          Show this help
+  -v, --version       Show version
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+type Command = 'color' | 'palette' | 'swatches';
+
+interface CliArgs {
+    command: Command;
+    files: string[];
+    json: boolean;
+    css: boolean;
+    count: number;
+    quality: number;
+    colorSpace: 'rgb' | 'oklch';
+}
+
+function parseCliArgs(argv: string[]): CliArgs {
+    const { values, positionals } = parseArgs({
+        args: argv.slice(2),
+        options: {
+            json: { type: 'boolean', default: false },
+            css: { type: 'boolean', default: false },
+            count: { type: 'string', default: '10' },
+            quality: { type: 'string', default: '10' },
+            'color-space': { type: 'string', default: 'oklch' },
+            help: { type: 'boolean', short: 'h', default: false },
+            version: { type: 'boolean', short: 'v', default: false },
+        },
+        allowPositionals: true,
+        strict: true,
+    });
+
+    if (values.help) {
+        console.log(HELP);
+        process.exit(0);
+    }
+
+    if (values.version) {
+        console.log(version);
+        process.exit(0);
+    }
+
+    let command: Command = 'color';
+    const files: string[] = [];
+
+    for (const pos of positionals) {
+        if (pos === 'color' || pos === 'palette' || pos === 'swatches') {
+            if (files.length === 0) {
+                command = pos;
+                continue;
+            }
+        }
+        files.push(pos);
+    }
+
+    if (files.length === 0) {
+        // Check if stdin is piped
+        if (!process.stdin.isTTY) {
+            files.push('-');
+        } else {
+            console.error('Error: No input files specified.\n');
+            console.log(HELP);
+            process.exit(1);
+        }
+    }
+
+    const count = parseInt(values.count as string, 10);
+    if (isNaN(count) || count < 2 || count > 20) {
+        console.error('Error: --count must be between 2 and 20.');
+        process.exit(1);
+    }
+
+    const quality = parseInt(values.quality as string, 10);
+    if (isNaN(quality) || quality < 1) {
+        console.error('Error: --quality must be a positive integer.');
+        process.exit(1);
+    }
+
+    const colorSpace = values['color-space'] as string;
+    if (colorSpace !== 'rgb' && colorSpace !== 'oklch') {
+        console.error('Error: --color-space must be "rgb" or "oklch".');
+        process.exit(1);
+    }
+
+    return {
+        command,
+        files,
+        json: values.json as boolean,
+        css: values.css as boolean,
+        count,
+        quality,
+        colorSpace,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Stdin reader
+// ---------------------------------------------------------------------------
+
+async function readStdin(): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+        chunks.push(chunk as Buffer);
+    }
+    return Buffer.concat(chunks);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+const supportsColor = !process.env['NO_COLOR'] && process.stdout.isTTY;
+
+function ansiSwatch(hex: string): string {
+    if (!supportsColor) return hex;
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return `\x1b[38;2;${r};${g};${b}m\u2587\u2587\x1b[0m ${hex}`;
+}
+
+function colorToJson(c: Color): Record<string, unknown> {
+    return {
+        hex: c.hex(),
+        rgb: c.rgb(),
+        hsl: c.hsl(),
+        oklch: c.oklch(),
+        isDark: c.isDark,
+        population: c.population,
+        proportion: c.proportion,
+    };
+}
+
+function swatchMapToJson(swatches: SwatchMap): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const role of Object.keys(swatches) as SwatchRole[]) {
+        const s = swatches[role];
+        result[role] = s ? colorToJson(s.color) : null;
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// CSS output
+// ---------------------------------------------------------------------------
+
+function colorCss(c: Color): string {
+    return `:root {\n    --color-dominant: ${c.hex()};\n}`;
+}
+
+function paletteCss(colors: Color[]): string {
+    const props = colors.map((c, i) => `    --color-${i + 1}: ${c.hex()};`).join('\n');
+    return `:root {\n${props}\n}`;
+}
+
+function swatchesCss(swatches: SwatchMap): string {
+    const props: string[] = [];
+    for (const role of Object.keys(swatches) as SwatchRole[]) {
+        const s = swatches[role];
+        const kebab = role.replace(/([A-Z])/g, '-$1').toLowerCase();
+        props.push(`    --swatch${kebab}: ${s ? s.color.hex() : 'none'};`);
+    }
+    return `:root {\n${props.join('\n')}\n}`;
+}
+
+// ---------------------------------------------------------------------------
+// ANSI output
+// ---------------------------------------------------------------------------
+
+function colorAnsi(c: Color): string {
+    return ansiSwatch(c.hex());
+}
+
+function paletteAnsi(colors: Color[]): string {
+    return colors.map(c => ansiSwatch(c.hex())).join('\n');
+}
+
+function swatchesAnsi(swatches: SwatchMap): string {
+    const lines: string[] = [];
+    for (const role of Object.keys(swatches) as SwatchRole[]) {
+        const s = swatches[role];
+        const label = role.padEnd(14);
+        lines.push(s ? `${label} ${ansiSwatch(s.color.hex())}` : `${label} —`);
+    }
+    return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function processFile(
+    source: string | Buffer,
+    args: CliArgs,
+): Promise<{ colorResult?: Color | null; paletteResult?: Color[] | null; swatchResult?: SwatchMap }> {
+    const opts = {
+        colorCount: args.count,
+        quality: args.quality,
+        colorSpace: args.colorSpace as 'rgb' | 'oklch',
+    };
+
+    switch (args.command) {
+        case 'color': {
+            const color = await getColor(source, opts);
+            return { colorResult: color };
+        }
+        case 'palette': {
+            const palette = await getPalette(source, opts);
+            return { paletteResult: palette };
+        }
+        case 'swatches': {
+            const swatches = await getSwatches(source, opts);
+            return { swatchResult: swatches };
+        }
+    }
+}
+
+function formatResult(
+    result: Awaited<ReturnType<typeof processFile>>,
+    args: CliArgs,
+): string {
+    if (args.json) {
+        if (result.colorResult !== undefined) {
+            return JSON.stringify(result.colorResult ? colorToJson(result.colorResult) : null, null, 2);
+        }
+        if (result.paletteResult !== undefined) {
+            return JSON.stringify(result.paletteResult ? result.paletteResult.map(colorToJson) : null, null, 2);
+        }
+        if (result.swatchResult !== undefined) {
+            return JSON.stringify(swatchMapToJson(result.swatchResult), null, 2);
+        }
+    }
+
+    if (args.css) {
+        if (result.colorResult !== undefined && result.colorResult) {
+            return colorCss(result.colorResult);
+        }
+        if (result.paletteResult !== undefined && result.paletteResult) {
+            return paletteCss(result.paletteResult);
+        }
+        if (result.swatchResult !== undefined) {
+            return swatchesCss(result.swatchResult!);
+        }
+    }
+
+    // Default ANSI
+    if (result.colorResult !== undefined) {
+        return result.colorResult ? colorAnsi(result.colorResult) : '(no color found)';
+    }
+    if (result.paletteResult !== undefined) {
+        return result.paletteResult ? paletteAnsi(result.paletteResult) : '(no palette found)';
+    }
+    if (result.swatchResult !== undefined) {
+        return swatchesAnsi(result.swatchResult);
+    }
+
+    return '';
+}
+
+async function main(): Promise<void> {
+    const args = parseCliArgs(process.argv);
+    const multiFile = args.files.length > 1;
+
+    if (args.json && multiFile) {
+        const combined: Record<string, unknown> = {};
+        for (const file of args.files) {
+            const source = file === '-' ? await readStdin() : file;
+            const label = file === '-' ? 'stdin' : file;
+            const result = await processFile(source, args);
+
+            if (result.colorResult !== undefined) {
+                combined[label] = result.colorResult ? colorToJson(result.colorResult) : null;
+            } else if (result.paletteResult !== undefined) {
+                combined[label] = result.paletteResult ? result.paletteResult.map(colorToJson) : null;
+            } else if (result.swatchResult !== undefined) {
+                combined[label] = swatchMapToJson(result.swatchResult);
+            }
+        }
+        console.log(JSON.stringify(combined, null, 2));
+        return;
+    }
+
+    for (const file of args.files) {
+        const source = file === '-' ? await readStdin() : file;
+        const result = await processFile(source, args);
+        const output = formatResult(result, args);
+
+        if (multiFile) {
+            const label = file === '-' ? 'stdin' : file;
+            console.log(`${label}:`);
+        }
+        console.log(output);
+    }
+}
+
+main().catch((err) => {
+    if (
+        err?.code === 'ERR_MODULE_NOT_FOUND' ||
+        err?.code === 'MODULE_NOT_FOUND' ||
+        (typeof err?.message === 'string' && err.message.includes('Cannot find module') && err.message.includes('sharp'))
+    ) {
+        console.error(
+            'Error: sharp is required for image decoding but was not found.\n\n' +
+            'Install it alongside colorthief:\n\n' +
+            '  npm install -g colorthief sharp\n'
+        );
+        process.exit(1);
+    }
+    console.error(err.message || err);
+    process.exit(1);
+});

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,0 +1,215 @@
+import { resolve } from 'path';
+import { execFile } from 'child_process';
+import { readFileSync } from 'fs';
+import { promisify } from 'util';
+import chai from 'chai';
+
+const expect = chai.expect;
+const execFileAsync = promisify(execFile);
+
+const cli = resolve(process.cwd(), 'dist/cli.js');
+const imgDir = resolve(process.cwd(), 'cypress/test-pages/img');
+const img = (name) => resolve(imgDir, name);
+
+function run(...args) {
+    return execFileAsync('node', [cli, ...args], { timeout: 15000 });
+}
+
+function runWithStdin(filePath, ...args) {
+    return new Promise((resolve, reject) => {
+        const child = execFile('node', [cli, ...args], { timeout: 15000 }, (err, stdout, stderr) => {
+            if (err) reject(err);
+            else resolve({ stdout, stderr });
+        });
+        const data = readFileSync(filePath);
+        child.stdin.write(data);
+        child.stdin.end();
+    });
+}
+
+// ===========================================================================
+// CLI
+// ===========================================================================
+
+describe('CLI', function () {
+    this.timeout(15000);
+
+    // -----------------------------------------------------------------------
+    // --help / --version
+    // -----------------------------------------------------------------------
+
+    it('--help shows usage', async function () {
+        const { stdout } = await run('--help');
+        expect(stdout).to.include('Usage:');
+        expect(stdout).to.include('colorthief');
+    });
+
+    it('-h shows usage', async function () {
+        const { stdout } = await run('-h');
+        expect(stdout).to.include('Usage:');
+    });
+
+    it('--version shows version', async function () {
+        const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8'));
+        const { stdout } = await run('--version');
+        expect(stdout.trim()).to.equal(pkg.version);
+    });
+
+    it('-v shows version', async function () {
+        const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf8'));
+        const { stdout } = await run('-v');
+        expect(stdout.trim()).to.equal(pkg.version);
+    });
+
+    // -----------------------------------------------------------------------
+    // color (default command)
+    // -----------------------------------------------------------------------
+
+    it('outputs hex for dominant color', async function () {
+        const { stdout } = await run(img('red.png'));
+        expect(stdout).to.match(/#[0-9a-f]{6}/i);
+    });
+
+    it('dominant color of red.png is close to red', async function () {
+        const { stdout } = await run(img('red.png'), '--json');
+        const data = JSON.parse(stdout);
+        expect(data.rgb.r).to.be.greaterThan(200);
+        expect(data.rgb.g).to.be.lessThan(50);
+        expect(data.rgb.b).to.be.lessThan(50);
+    });
+
+    // -----------------------------------------------------------------------
+    // --json
+    // -----------------------------------------------------------------------
+
+    it('--json returns valid JSON with expected fields', async function () {
+        const { stdout } = await run(img('red.png'), '--json');
+        const data = JSON.parse(stdout);
+        expect(data).to.have.property('hex');
+        expect(data).to.have.property('rgb');
+        expect(data).to.have.property('hsl');
+        expect(data).to.have.property('oklch');
+        expect(data).to.have.property('isDark');
+        expect(data).to.have.property('population');
+        expect(data).to.have.property('proportion');
+    });
+
+    // -----------------------------------------------------------------------
+    // palette
+    // -----------------------------------------------------------------------
+
+    it('palette subcommand returns array in JSON mode', async function () {
+        const { stdout } = await run('palette', img('rainbow-horizontal.png'), '--json');
+        const data = JSON.parse(stdout);
+        expect(data).to.be.an('array');
+        expect(data.length).to.be.greaterThan(1);
+        expect(data[0]).to.have.property('hex');
+    });
+
+    it('palette --count limits colors', async function () {
+        const { stdout } = await run('palette', img('rainbow-horizontal.png'), '--json', '--count', '3');
+        const data = JSON.parse(stdout);
+        expect(data).to.be.an('array');
+        expect(data.length).to.be.at.most(3);
+    });
+
+    it('palette default output shows hex values', async function () {
+        const { stdout } = await run('palette', img('rainbow-horizontal.png'));
+        const hexes = stdout.match(/#[0-9a-f]{6}/gi);
+        expect(hexes).to.not.be.null;
+        expect(hexes.length).to.be.greaterThan(1);
+    });
+
+    // -----------------------------------------------------------------------
+    // swatches
+    // -----------------------------------------------------------------------
+
+    it('swatches returns all roles in JSON', async function () {
+        const { stdout } = await run('swatches', img('rainbow-horizontal.png'), '--json');
+        const data = JSON.parse(stdout);
+        const expectedRoles = ['Vibrant', 'Muted', 'DarkVibrant', 'DarkMuted', 'LightVibrant', 'LightMuted'];
+        for (const role of expectedRoles) {
+            expect(data).to.have.property(role);
+        }
+    });
+
+    it('swatches default output shows role names', async function () {
+        const { stdout } = await run('swatches', img('rainbow-horizontal.png'));
+        expect(stdout).to.include('Vibrant');
+        expect(stdout).to.include('Muted');
+    });
+
+    // -----------------------------------------------------------------------
+    // --css
+    // -----------------------------------------------------------------------
+
+    it('--css for color outputs custom properties', async function () {
+        const { stdout } = await run(img('red.png'), '--css');
+        expect(stdout).to.include(':root');
+        expect(stdout).to.include('--color-dominant');
+    });
+
+    it('--css for palette outputs numbered properties', async function () {
+        const { stdout } = await run('palette', img('rainbow-horizontal.png'), '--css');
+        expect(stdout).to.include(':root');
+        expect(stdout).to.include('--color-1');
+    });
+
+    it('--css for swatches outputs swatch properties', async function () {
+        const { stdout } = await run('swatches', img('rainbow-horizontal.png'), '--css');
+        expect(stdout).to.include(':root');
+        expect(stdout).to.include('--swatch-vibrant');
+        expect(stdout).to.include('--swatch-dark-muted');
+    });
+
+    // -----------------------------------------------------------------------
+    // stdin
+    // -----------------------------------------------------------------------
+
+    it('reads from stdin with "-" argument', async function () {
+        const { stdout } = await runWithStdin(img('red.png'), '-', '--json');
+        const data = JSON.parse(stdout);
+        expect(data).to.have.property('hex');
+        expect(data.rgb.r).to.be.greaterThan(200);
+    });
+
+    // -----------------------------------------------------------------------
+    // multi-file
+    // -----------------------------------------------------------------------
+
+    it('multi-file JSON wraps in object keyed by filename', async function () {
+        const { stdout } = await run(img('red.png'), img('black.png'), '--json');
+        const data = JSON.parse(stdout);
+        expect(data).to.have.property(img('red.png'));
+        expect(data).to.have.property(img('black.png'));
+    });
+
+    it('multi-file default output prefixes with filename', async function () {
+        const { stdout } = await run(img('red.png'), img('black.png'));
+        expect(stdout).to.include('red.png:');
+        expect(stdout).to.include('black.png:');
+    });
+
+    // -----------------------------------------------------------------------
+    // --color-space
+    // -----------------------------------------------------------------------
+
+    it('--color-space rgb works', async function () {
+        const { stdout } = await run(img('red.png'), '--json', '--color-space', 'rgb');
+        const data = JSON.parse(stdout);
+        expect(data).to.have.property('hex');
+    });
+
+    // -----------------------------------------------------------------------
+    // error cases
+    // -----------------------------------------------------------------------
+
+    it('exits with error for missing file', async function () {
+        try {
+            await run('nonexistent.png');
+            expect.fail('should have thrown');
+        } catch (err) {
+            expect(err.code).to.not.equal(0);
+        }
+    });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -71,6 +71,17 @@ export default defineConfig([
             ];
         },
     },
+    // CLI
+    {
+        entry: { cli: 'src/cli.ts' },
+        outDir: 'dist',
+        format: ['esm'],
+        splitting: false,
+        dts: false,
+        sourcemap: false,
+        external: ['sharp'],
+        banner: { js: '#!/usr/bin/env node' },
+    },
     // Type declarations
     {
         entry: {


### PR DESCRIPTION
Adds `colorthief` CLI with color, palette, and swatches subcommands. Supports --json, --css, and ANSI output formats, stdin piping, multi-file input, and a friendly error message when sharp is not installed.