### PR TITLE
fix: remove dangling WASM import that warned in bundlers

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,7 +29,7 @@ A Rust implementation of the full MMCQ algorithm lives in `src/wasm/`, and the `
 **Current state (power-user only):**
 1. Install the Rust toolchain and `wasm-pack`.
 2. Run `wasm-pack build --target web` in `src/wasm/`.
-3. Point `WasmQuantizer` at the generated `.wasm` file.
+3. Pass the generated glue module to `WasmQuantizer` — `new WasmQuantizer(await import('./pkg/color_thief_wasm.js'))`.
 
 **Goal — drop-in replacement, no build step:**
 - Pre-compile the `.wasm` and ship it as a published artifact (e.g. a `@colorthief/wasm` package, or a bundled binary loaded on demand) so consumers get it without a Rust toolchain.

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,7 +27,8 @@ let globalQuantizer: Quantizer | null = null;
  * ```ts
  * import { configure } from 'colorthief';
  * import { WasmQuantizer } from 'colorthief/internals';
- * const q = new WasmQuantizer();
+ * import * as wasm from './src/wasm/pkg/color_thief_wasm.js'; // built with wasm-pack
+ * const q = new WasmQuantizer(wasm);
  * await q.init();
  * configure({ quantizer: q });
  * ```

--- a/src/quantizers/wasm.ts
+++ b/src/quantizers/wasm.ts
@@ -1,53 +1,72 @@
 import type { Quantizer } from '../types.js';
 
 /**
- * WASM-based MMCQ quantizer. Loads the WASM module built from Rust.
+ * The wasm-bindgen glue module produced by `wasm-pack build --target web`.
+ * `default` is the init function that instantiates the `.wasm` binary.
+ */
+export interface WasmModule {
+    default?: (init?: { module_or_path: string | URL }) => Promise<unknown>;
+    quantize: (pixels: Uint8Array, maxColors: number) => Uint8Array;
+}
+
+/**
+ * WASM-based MMCQ quantizer.
  *
- * Build the WASM module first:
- *   cd src/wasm && wasm-pack build --target web --out-dir ../../dist/wasm
+ * The WASM binary is **not** shipped with the npm package — the Rust source
+ * lives in `src/wasm/` and must be compiled, then handed to this class:
  *
- * Usage:
+ * ```sh
+ * npx wasm-pack build src/wasm --target web
+ * ```
+ *
  * ```ts
- * import { configure, WasmQuantizer } from 'colorthief';
- * const q = new WasmQuantizer();
+ * import { configure } from 'colorthief';
+ * import { WasmQuantizer } from 'colorthief/internals';
+ * import * as wasm from './path/to/src/wasm/pkg/color_thief_wasm.js';
+ *
+ * const q = new WasmQuantizer(wasm);
  * await q.init();
  * configure({ quantizer: q });
  * ```
  */
 export class WasmQuantizer implements Quantizer {
     private wasmQuantize: ((pixels: Uint8Array, maxColors: number) => Uint8Array) | null = null;
+    private module: WasmModule | undefined;
     private wasmUrl: string | URL | undefined;
 
     /**
-     * @param wasmUrl - Optional URL to the .wasm file. If not provided,
-     *                  attempts to load from the default dist location.
+     * @param module - The wasm-bindgen glue module (see class docs). Required
+     *                 before `init()` can succeed.
+     * @param wasmUrl - Optional explicit location of the `.wasm` binary,
+     *                  forwarded to the module's init function. Useful when the
+     *                  binary is served from a path the glue can't infer.
      */
-    constructor(wasmUrl?: string | URL) {
+    constructor(module?: WasmModule, wasmUrl?: string | URL) {
+        this.module = module;
         this.wasmUrl = wasmUrl;
     }
 
     async init(): Promise<void> {
         if (this.wasmQuantize) return;
 
-        // Try to dynamically import the wasm-bindgen generated JS glue
+        if (!this.module) {
+            throw new Error(
+                'WasmQuantizer requires the wasm-bindgen module built from src/wasm. ' +
+                'Build it with `npx wasm-pack build src/wasm --target web`, then pass the ' +
+                'generated glue module: `new WasmQuantizer(await import("./pkg/color_thief_wasm.js"))`.',
+            );
+        }
+
         try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let wasm: any;
-            if (this.wasmUrl) {
-                // For environments where the wasm file needs explicit loading
-                const response = await fetch(this.wasmUrl);
-                const bytes = await response.arrayBuffer();
-                const module = await WebAssembly.compile(bytes);
-                const instance = await WebAssembly.instantiate(module);
-                wasm = instance.exports;
-            } else {
-                // Default: try importing the wasm-pack output
-                wasm = await import('../../dist/wasm/color_thief_wasm.js' as string);
-                if (wasm.default && typeof wasm.default === 'function') {
-                    await wasm.default();
-                }
+            if (typeof this.module.default === 'function') {
+                await this.module.default(
+                    this.wasmUrl ? { module_or_path: this.wasmUrl } : undefined,
+                );
             }
-            this.wasmQuantize = wasm.quantize;
+            if (typeof this.module.quantize !== 'function') {
+                throw new Error('module does not export a `quantize` function');
+            }
+            this.wasmQuantize = this.module.quantize;
         } catch (e) {
             throw new Error(
                 `Failed to initialize WASM quantizer: ${e instanceof Error ? e.message : String(e)}`,

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -15,6 +15,7 @@ import {
     validateOptions,
     MmcqQuantizer,
     createNodeLoader,
+    WasmQuantizer,
 } from '../dist/internals.js';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -714,5 +715,67 @@ describe('custom Node decoder', function() {
         const color = await getColor('ignored-source', { loader });
         expect(color.array()).to.deep.equal([12, 34, 56]);
         expect(color.gamut).to.equal('srgb');
+    });
+});
+
+// ===========================================================================
+// WASM quantizer (issue #283)
+// ===========================================================================
+
+describe('WasmQuantizer', function() {
+    it('throws a build-instruction error when no module is supplied', async function() {
+        const q = new WasmQuantizer();
+        await expect(q.init()).to.be.rejectedWith(/wasm-pack build src\/wasm/);
+    });
+
+    it('initializes from a supplied wasm-bindgen module', async function() {
+        let initArgs = 'not called';
+        const fakeModule = {
+            default: async (arg) => { initArgs = arg; },
+            // 7 bytes per color: r, g, b, population as uint32 little-endian
+            quantize: () => new Uint8Array([10, 20, 30, 4, 0, 0, 0]),
+        };
+        const q = new WasmQuantizer(fakeModule);
+        await q.init();
+        expect(initArgs).to.equal(undefined);
+        expect(q.quantize([[10, 20, 30]], 2)).to.deep.equal([
+            { color: [10, 20, 30], population: 4 },
+        ]);
+    });
+
+    it('forwards an explicit wasmUrl to the module init function', async function() {
+        let initArgs = null;
+        const q = new WasmQuantizer(
+            { default: async (arg) => { initArgs = arg; }, quantize: () => new Uint8Array() },
+            'https://example.com/color_thief_wasm_bg.wasm',
+        );
+        await q.init();
+        expect(initArgs).to.deep.equal({
+            module_or_path: 'https://example.com/color_thief_wasm_bg.wasm',
+        });
+    });
+
+    it('requires init() before quantize()', function() {
+        expect(() => new WasmQuantizer().quantize([[1, 2, 3]], 2)).to.throw(/init\(\)/);
+    });
+});
+
+describe('bundler-visible imports (issue #283)', function() {
+    // The published package has never contained dist/wasm/. Any reference to it
+    // makes bundlers warn about an unresolvable module.
+    const bundles = [
+        'dist/internals.js',
+        'dist/internals.cjs',
+        'dist/internals.browser.js',
+        'dist/internals.browser.cjs',
+        'dist/index.js',
+        'dist/index.browser.js',
+    ];
+
+    bundles.forEach((file) => {
+        it(`${file} contains no reference to the unshipped dist/wasm directory`, function() {
+            const source = readFileSync(resolve(process.cwd(), file), 'utf8');
+            expect(source).to.not.match(/dist\/wasm/);
+        });
     });
 });


### PR DESCRIPTION
Closes #283.

## The problem

`WasmQuantizer` fell back to `import('../../dist/wasm/color_thief_wasm.js')` when constructed with no arguments. That file has never been in the published tarball — I confirmed with `npm pack colorthief@3.4.0` that `dist/wasm/` doesn't exist in any release. Bundlers resolving `colorthief/internals` (to pull in something like `oklchToRgb`) see a specifier they can't resolve and warn about it, as reported in #283.

The other code path was broken too: `new WasmQuantizer(url)` fetched the `.wasm` and called `WebAssembly.instantiate` directly, but `lib.rs` exposes `#[wasm_bindgen] pub fn quantize(pixels: &[u8], max_colors: usize) -> Vec<u8>`, whose marshalling requires the wasm-bindgen JS glue. So both paths were non-functional as published — this fix breaks nothing that previously worked.

## The fix

The glue module is supplied by the caller:

```js
import { WasmQuantizer } from 'colorthief/internals';
const q = new WasmQuantizer(await import('./pkg/color_thief_wasm.js'));
await q.init();
```

`init()` with no module throws a message pointing at the `wasm-pack` build step instead of failing on a path that was never shipped. An optional second argument still forwards an explicit `.wasm` location to the glue's init.

## Verification

Reproduced the reporter's warning with rspack (what Rsbuild uses) against published 3.4.0:

```
⚠ Module not found: Can't resolve '../../dist/wasm/color_thief_wasm.js'
```

Then installed an `npm pack` of this branch into the same project: clean build, no warnings, no `wasm` reference in the output bundle, and the bundled `oklchToRgb` returns the correct value.

New regression coverage: `WasmQuantizer` init/error behavior, plus an assertion that no built bundle references the unshipped `dist/wasm` path.

## Scope

This is the minimal patch for the warning. Actually shipping a precompiled WASM binary — @magic-akari's #284 — is the better long-term answer, but it makes `npm run build` require a Rust toolchain and needs CI changes and test coverage, so it belongs in 3.5.0 rather than a patch release. #284 stays open for that.