### PR TITLE
Guard against referenced-but-unpublished files in the tarball

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm run build
+      - run: npm run typecheck
+      - run: npm run check:package
       - run: npm run test:node
 
   browser-tests:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,20 @@ The `worker` option became a no-op in v3.5 and the `isWorkerSupported` / `extrac
 
 Why it went: the worker only ever offloaded quantization, while decode, pixel sampling, and the structured clone of the pixel array stayed on the main thread — and serializing `Array<[r, g, b]>` cost several times more than the quantization it saved (at 2 MP / quality 10, ~20 ms of clone to avoid ~2.5 ms of quantize; the gap widens with image size). It also carried a hand-inlined copy of MMCQ that drifted from the real one: it quantized in RGB while the main path defaults to OKLCH, and skipped the few-color short-circuit and filter relaxation, so `worker: true` returned different colors than the default. The supported answer is to run Color Thief inside your own worker with an `ImageBitmap` source, which moves the whole pipeline off-thread and transfers pixels without copying.
 
+## v4 breaking change: raise the `sharp` and Node floors
+
+`peerDependencies` currently accepts `sharp: ">=0.33.0"`, but every sharp below 0.35.0 inherits four libvips CVEs ([GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj): CVE-2026-33327, CVE-2026-33328, CVE-2026-35590, CVE-2026-35591). Anyone auditing a project that installs Color Thief's Node path can satisfy our range with a vulnerable sharp.
+
+The fix is `sharp: ">=0.35.0"`, and it can't ship in a 3.x minor: sharp 0.35 requires `node >=20.9.0`, so raising the sharp floor drops Node 18. That's a breaking change twice over — for anyone pinned to sharp 0.34 and for anyone still on Node 18.
+
+Bundled into v4:
+- `peerDependencies.sharp` → `">=0.35.0"`.
+- Add the `engines` field the package has never declared: `node >=20.9.0`. Today npm gives consumers no signal at all about supported Node.
+- Move the CI matrix off 18 (EOL April 2025) to 20/22/24, and update `.nvmrc`.
+- Bump the `sharp` devDependency in lockstep so CI stops testing against the vulnerable line.
+
+Until then 3.x keeps the wider range: sharp is an *optional* peer, browser users never install it, and Node users can and should choose 0.35+ themselves.
+
 ## Big bet: accessible scheme generation
 
 Move Color Thief from a raw extractor toward a theming toolkit by generating a balanced, accessible N-role color scheme from an image — the space Material Color Utilities (HCT) targets. This is the largest differentiator and the direction the market is heading (dynamic/adaptive theming). We're already partway there: OKLCH quantization, semantic swatches, WCAG contrast, and `textColor` are all in place. The new work is scheme *synthesis* — deriving a harmonious, contrast-safe set of roles rather than just reporting the colors that are present. Hard; scope before committing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,9 +1762,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3861,9 +3861,9 @@
             }
         },
         "node_modules/mocha": {
-            "version": "11.7.6",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.6.tgz",
-            "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
+            "version": "11.8.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+            "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,8 +82,9 @@
     "module": "./dist/index.js",
     "types": "./dist/types/index.d.ts",
     "scripts": {
-        "prepublishOnly": "npm run build",
+        "prepublishOnly": "npm run build && npm run check:package",
         "build": "tsup",
+        "check:package": "node scripts/check-package.mjs",
         "watch": "tsup --watch",
         "dev": "http-server",
         "test": "mocha && cypress run --config video=false",

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------------------
+// Package contents check
+//
+// Guards the class of bug behind #283: dist/ shipped an import of
+// `dist/wasm/color_thief_wasm.js`, a file the published tarball never
+// contained. Builds still worked — the dead code was tree-shaken — but every
+// bundler resolving `colorthief/internals` printed an unresolvable-import
+// warning, and nothing in CI noticed.
+//
+// Three assertions, all made against the file list npm would actually publish:
+//   1. Every path package.json points at (exports, main, module, types, bin)
+//      is in the tarball.
+//   2. Every relative specifier emitted into dist/ resolves to a file in the
+//      tarball.
+//   3. The browser bundles carry no reference to sharp, the Node-only optional
+//      peer dep.
+//
+// Reads dist/ as it stands on disk, so run it after `npm run build`.
+// ---------------------------------------------------------------------------
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const errors = [];
+
+const toPosix = (p) => p.split(path.sep).join('/');
+const stripDotSlash = (p) => p.replace(/^\.\//, '');
+
+// --- The file list npm would publish ---------------------------------------
+
+const [packResult] = JSON.parse(
+    execFileSync('npm', ['pack', '--dry-run', '--json'], {
+        cwd: root,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+    }),
+);
+const packed = new Set(packResult.files.map((f) => f.path));
+
+// --- 1. package.json entry points -------------------------------------------
+
+// exports is a nested condition map, so walk it rather than reading fixed keys.
+function collectPaths(value, out = []) {
+    if (typeof value === 'string') {
+        if (value.startsWith('./') || value.startsWith('dist/')) out.push(value);
+    } else if (value && typeof value === 'object') {
+        for (const nested of Object.values(value)) collectPaths(nested, out);
+    }
+    return out;
+}
+
+const pkg = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'));
+const entryPoints = collectPaths([pkg.exports, pkg.main, pkg.module, pkg.types, pkg.bin]);
+
+for (const entry of new Set(entryPoints.map(stripDotSlash))) {
+    if (!packed.has(entry)) {
+        errors.push(`package.json points at "${entry}", which the published tarball does not contain`);
+    }
+}
+
+// --- 2. Relative specifiers emitted into dist/ ------------------------------
+
+function walk(dir, out = []) {
+    for (const name of readdirSync(dir)) {
+        const full = path.join(dir, name);
+        if (statSync(full).isDirectory()) walk(full, out);
+        else out.push(full);
+    }
+    return out;
+}
+
+// Source maps embed the original sources, imports and all — scanning them would
+// report specifiers that only ever existed pre-bundle.
+const CODE_FILE = /\.(js|cjs|mjs|d\.ts|d\.cts|d\.mts)$/;
+// Covers `from "x"` (static import and re-export), `import("x")`, `require("x")`,
+// and the bare side-effect `import "x"`. The \0 delimiters cannot occur in real
+// source, so a placeholder can never be confused for a genuine specifier.
+const SPECIFIER = /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*|\bimport\s+)"\0(\d+)\0"/g;
+
+// Replace every comment with blanks and every string literal with an opaque
+// placeholder, so the specifier regex only ever fires on real code. Both
+// matter here: doc comments carry illustrative imports, and WasmQuantizer's
+// "you must build this yourself" error message quotes an `import(...)` call
+// inside a string. Neither is a reference a bundler would try to resolve.
+function maskLiterals(code) {
+    const values = [];
+    let masked = '';
+    let i = 0;
+
+    // Distinguishes a regex literal from division by what precedes the slash —
+    // the usual heuristic, and enough for generated bundles.
+    const regexCanFollow = () => /[([{,;:=!&|?+\-*~^%<>]\s*$|^\s*$|\b(return|typeof|case|in|of|new|delete|void)\s*$/.test(masked);
+
+    while (i < code.length) {
+        const char = code[i];
+        const pair = code.slice(i, i + 2);
+
+        if (pair === '//' || pair === '/*') {
+            const end = pair === '//'
+                ? (code.indexOf('\n', i) === -1 ? code.length : code.indexOf('\n', i))
+                : (code.indexOf('*/', i + 2) === -1 ? code.length : code.indexOf('*/', i + 2) + 2);
+            // Keep newlines so line-comment handling stays sane on the next pass.
+            masked += code.slice(i, end).replace(/[^\n]/g, ' ');
+            i = end;
+            continue;
+        }
+
+        if (char === '"' || char === "'" || char === '`') {
+            let j = i + 1;
+            let value = '';
+            while (j < code.length && code[j] !== char) {
+                if (code[j] === '\\') {
+                    value += code[j + 1] ?? '';
+                    j += 2;
+                    continue;
+                }
+                value += code[j];
+                j += 1;
+            }
+            masked += `"\0${values.length}\0"`;
+            values.push(value);
+            i = j + 1;
+            continue;
+        }
+
+        if (char === '/' && regexCanFollow()) {
+            let j = i + 1;
+            let inClass = false;
+            while (j < code.length) {
+                if (code[j] === '\\') { j += 2; continue; }
+                if (code[j] === '[') inClass = true;
+                else if (code[j] === ']') inClass = false;
+                else if (code[j] === '/' && !inClass) break;
+                else if (code[j] === '\n') break;
+                j += 1;
+            }
+            masked += ' '.repeat(j - i + 1);
+            i = j + 1;
+            continue;
+        }
+
+        masked += char;
+        i += 1;
+    }
+
+    return { masked, values };
+}
+
+// A .d.ts references its siblings by the .js specifier they will compile to;
+// the file on disk is the matching declaration.
+function resolutionCandidates(fromFile, specifier) {
+    const target = toPosix(path.normalize(path.join(path.dirname(fromFile), specifier)));
+    const candidates = [target];
+    if (/\.d\.(ts|cts|mts)$/.test(fromFile)) {
+        candidates.push(
+            target.replace(/\.js$/, '.d.ts'),
+            target.replace(/\.cjs$/, '.d.cts'),
+            target.replace(/\.mjs$/, '.d.mts'),
+        );
+    }
+    return candidates;
+}
+
+for (const file of walk(path.join(root, 'dist'))) {
+    const rel = toPosix(path.relative(root, file));
+    if (!CODE_FILE.test(rel) || !packed.has(rel)) continue;
+
+    const { masked, values } = maskLiterals(readFileSync(file, 'utf8'));
+    for (const [, index] of masked.matchAll(SPECIFIER)) {
+        const specifier = values[Number(index)];
+        if (!specifier.startsWith('.')) continue; // bare specifier — a dependency, not our file
+        if (!resolutionCandidates(rel, specifier).some((c) => packed.has(c))) {
+            errors.push(`${rel} imports "${specifier}", which the published tarball does not contain`);
+        }
+    }
+}
+
+// --- 3. No sharp in the browser bundles -------------------------------------
+
+const BROWSER_BUNDLES = [
+    'dist/index.browser.js',
+    'dist/index.browser.cjs',
+    'dist/internals.browser.js',
+    'dist/internals.browser.cjs',
+];
+
+for (const rel of BROWSER_BUNDLES) {
+    if (!packed.has(rel)) {
+        errors.push(`expected browser bundle "${rel}" is missing from the published tarball`);
+        continue;
+    }
+    if (/\bsharp\b/.test(readFileSync(path.join(root, rel), 'utf8'))) {
+        errors.push(`${rel} references sharp — the browser build must not pull in the Node loader`);
+    }
+}
+
+// --- Report -----------------------------------------------------------------
+
+if (errors.length > 0) {
+    console.error(`Package contents check failed (${errors.length}):\n`);
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+}
+
+console.log(`Package contents OK — ${packed.size} files, all references resolve.`);


### PR DESCRIPTION
Follow-up to #283 / #285, plus two pieces of maintenance that surfaced alongside it.

No user-facing change — `src/` is untouched, so the built library is byte-identical to 3.5.0. Nothing here needs a release or a CHANGELOG entry.

## Add a package contents check to CI

3.4.1 fixed a dangling import of `dist/wasm/color_thief_wasm.js`, a file the published tarball never contained. Builds still succeeded — the dead code was tree-shaken — but every bundler resolving `colorthief/internals` printed an unresolvable-import warning, and nothing in CI noticed. `scripts/check-package.mjs` makes that class of bug fail loudly, asserting three things against the file list `npm pack` would actually produce:

1. Every path `package.json` points at (exports, main, module, types, bin) is in the tarball.
2. Every relative specifier emitted into `dist/` resolves to a file in the tarball.
3. The browser bundles carry no reference to `sharp`, so the Node loader can't leak into a browser build.

A plain regex over `dist/` is unusable for (2) — it reports four false positives on the current tree, because `WasmQuantizer`'s "build this yourself" error message quotes an `import(...)` call inside a string, and the generated `.d.ts` doc comments show an illustrative import path. The scanner therefore blanks comments and replaces string literals with opaque placeholders before matching, and resolves the `.js` specifiers declaration files use to the `.d.ts` siblings actually on disk.

Verified it fails on all four import forms — bare side-effect `import`, dynamic `import()` (the exact #283 shape), `require()`, and re-export — plus a `sharp` leak and a `package.json` entry pointing at an unpublished file, while staying quiet on specifiers inside strings and comments.

Also wires in `npm run typecheck`, which has existed as a script but never ran in CI, and adds the check to `prepublishOnly` so a bad tarball can't go out even when publishing by hand.

## Apply the non-breaking npm audit fix

`brace-expansion` 2.1.1 → 2.1.4, clearing two high-severity DoS advisories. Lockfile only; no ranges change. `esbuild` is left alone deliberately — the fix is in 0.28.1 but tsup pins `^0.27.0`, and the advisory covers arbitrary file read via esbuild's dev server on Windows, which tsup never starts.

## Queue the sharp/Node floor bump for v4

`peerDependencies` accepts `sharp: ">=0.33.0"`, but every sharp below 0.35.0 inherits four libvips CVEs ([GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj)). It can't be fixed in a 3.x minor: sharp 0.35 requires `node >=20.9.0`, so raising the floor also drops Node 18. ROADMAP records the full v4 change set, including the `engines` field the package has never declared.

## Testing

`npm run build`, `npm run typecheck`, `npm run check:package`, and all 183 node tests pass locally. Cypress not run — nothing here touches browser behavior, but CI will cover it.